### PR TITLE
Enable theme for Jekyll page everywhere

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,8 @@
 title: Beaker-Next Design
+# Used by GitHub Pages
 remote_theme: "pmarsceill/just-the-docs"
+# Used in standalone version
+theme: "just-the-docs"
 baseurl: "/beaker-next-design/"
 aux_links:
   "GitHub repo":


### PR DESCRIPTION
This patch makes sure we can render theme in GitHub Pages but also in standalone mode which is used by netlify.
Fixes: #7 
Signed-off-by: Martin Styk <mastyk@redhat.com>